### PR TITLE
Support for mongoid_5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Use 0.3.0 for mongoid 3.0
 
 Use 4.x.x for mongoid 4
 
+Use 5.x.x for mongoid 5
+
 ## Installation
 
 in gemfile:

--- a/gemfiles/mongoid_3.gemfile
+++ b/gemfiles/mongoid_3.gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem 'mongoid', '~> 3.0.0'
+gem 'mongoid', '~> 5.0.0.beta'
 gem 'rspec'
 gem 'activesupport'
 gem 'rake'

--- a/lib/autoinc/incrementor.rb
+++ b/lib/autoinc/incrementor.rb
@@ -50,7 +50,7 @@ module Mongoid
       #
       # @return [ Integer ] The next value of the incrementor
       def inc
-        find.modify({'$inc' => {c: step}}, new: true, upsert: true).fetch('c')
+        find.find_one_and_update({'$inc' => {c: step}}, upsert: true, return_document: :after).fetch('c')
       end
 
       private
@@ -65,7 +65,7 @@ module Mongoid
       # Persists the incrementor using +key+ as id and +seed+ as value of +c+.
       #
       def create
-        collection.insert(_id: key, c: seed)
+        collection.insert_one(_id: key, c: seed)
       end
 
       # Checks if the incrementor is persisted

--- a/lib/autoinc/incrementor.rb
+++ b/lib/autoinc/incrementor.rb
@@ -34,7 +34,7 @@ module Mongoid
         @scope_key = options.fetch(:scope, nil)
         @step = options.fetch(:step, 1)
         @seed = options.fetch(:seed, nil)
-        @collection = ::Mongoid.default_session['auto_increment_counters']
+        @collection = ::Mongoid.default_client['auto_increment_counters']
         create if @seed && !exists?
       end
 

--- a/lib/autoinc/version.rb
+++ b/lib/autoinc/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Autoinc
-    VERSION = '4.0.0'
+    VERSION = '5.0.0'
   end
 end

--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', '~> 4.0'
+  s.add_dependency 'mongoid', '~> 5.0.0.beta'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'


### PR DESCRIPTION
Hi folks. This is an updated version of mongoid-autoinc that supports mongoid_5.0.0 (currently still in beta)

> The underlying driver has changed from Moped to the official MongoDB Ruby driver.
http://docs.mongodb.org/ecosystem/tutorial/ruby-mongoid-tutorial/#upgrading-to-5-0-0

References: 
- http://api.mongodb.org/ruby/current/Mongo/Collection/View/Writable.html#update_one-instance_method