### PR TITLE
Update mongoid-autoinc.gemspec

### DIFF
--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', '~> 5.0.0'
+  s.add_dependency 'mongoid', '>= 5.0.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'

--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', '>= 5.0.0'
+  s.add_dependency 'mongoid', '~> 5.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'


### PR DESCRIPTION
Updated Mongoid dependency to ``>= 5.0.0`` otherwise the gem appears to look for ver 5.0.0 *only*.