### PR TITLE
Mongoid 7 support

### DIFF
--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', '~> 6.0'
+  s.add_dependency 'mongoid', ['>= 6.0', '< 8.0']
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'

--- a/spec/autoinc_spec.rb
+++ b/spec/autoinc_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 describe 'Mongoid::Autoinc' do
   after { User.delete_all }
@@ -115,6 +116,7 @@ describe 'Mongoid::Autoinc' do
         expect(Mongoid::Autoinc::Incrementor).to receive(:new)
           .with('Operation', :op_number, scope: 'Dr. Cox', auto: true)
           .and_return(incrementor)
+        user.save!
         operation.save!
       end
     end

--- a/spec/autoinc_spec.rb
+++ b/spec/autoinc_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe 'Mongoid::Autoinc' do
   after { User.delete_all }


### PR DESCRIPTION
One spec needed to be fixed. 
Mongoid 7 will no longer save a parent (User) when a child is saved (Operation).