### PR TITLE
Add support for Mongoid version 8

### DIFF
--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', ['>= 6.0', '< 8.0']
+  s.add_dependency 'mongoid', ['>= 6.0', '< 9.0']
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'


### PR DESCRIPTION
Adds support for Mongoid version 8. I ran the specs using Mongoid 8.1.1 and everything seems to work as expected.

<img width="539" alt="Screenshot 2023-07-24 at 08 43 52" src="https://github.com/suweller/mongoid-autoinc/assets/18333420/b6c82ebf-caa8-4f26-9647-708f6181f8eb">
