### PR TITLE
chore: bump mongoid dependency to <10

### DIFF
--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', ['>= 6.0', '< 9.0']
+  s.add_dependency 'mongoid', ['>= 6.0', '< 10.0']
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'


### PR DESCRIPTION
ran tests against mongoid 9, ruby 3.2 and mongodb v8 and all is passing

<img width="1791" alt="Screenshot 2024-09-27 at 2 37 51 PM" src="https://github.com/user-attachments/assets/e96780e1-afa8-4b82-8723-94692aaf5606">
