### PR TITLE
CI: add github ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mongodb: [4.0, 5.0, 6.0, 7.0, 8.0]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
+        gemfile:
+          - mongoid_6
+          - mongoid_7
+          - mongoid_8
+          - mongoid_9
+    name: Ruby ${{ matrix.ruby }} with ${{ matrix.gemfile }} and mongodb ${{ matrix.mongodb }}
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+    steps:
+      - name: Set up MongoDB ${{ matrix.mongodb }}
+        uses: supercharge/mongodb-github-action@1.11.0
+        with:
+          mongodb-version: ${{ matrix.mongodb }}
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@
 A mongoid plugin to add auto incrementing fields to your documents.
 
 [![Inline docs](
-http://inch-ci.org/github/suweller/mongoid-autoinc.svg?branch=master&style=flat
-)](http://inch-ci.org/github/suweller/mongoid-autoinc)
-[![Code Climate](
-http://img.shields.io/codeclimate/github/suweller/mongoid-autoinc.svg?style=flat
-)](https://codeclimate.com/github/suweller/mongoid-autoinc)
+https://inch-ci.org/github/suweller/mongoid-autoinc.svg?branch=master&style=flat
+)](https://inch-ci.org/github/suweller/mongoid-autoinc)
+[![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/suweller/mongoid-autoinc)](https://codeclimate.com/github/suweller/mongoid-autoinc)
 [![Build Status](
-http://img.shields.io/travis/suweller/mongoid-autoinc.svg?style=flat
-)](https://travis-ci.org/suweller/mongoid-autoinc)
+https://github.com/suweller/mongoid-autoinc/actions/workflows/ci.yml/badge.svg?branch=master
+)](https://github.com/suweller/mongoid-autoinc/actions)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ increments :number, step: -> { 1 + rand(10) }
 ```
 $ gem install bundler (if you don't have it)
 $ bundle install
-$ bundle exec spec
+$ bundle exec rake
 ```
 
 ## Contributing

--- a/gemfiles/mongoid_5.gemfile
+++ b/gemfiles/mongoid_5.gemfile
@@ -1,6 +1,0 @@
-source :rubygems
-
-gem 'mongoid', '~> 5.0'
-gem 'rspec'
-gem 'activesupport'
-gem 'rake'

--- a/gemfiles/mongoid_6.gemfile
+++ b/gemfiles/mongoid_6.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 6.0"
+
+gemspec path: "../"

--- a/gemfiles/mongoid_7.gemfile
+++ b/gemfiles/mongoid_7.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 7.0"
+
+gemspec path: "../"

--- a/gemfiles/mongoid_8.gemfile
+++ b/gemfiles/mongoid_8.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 8.0"
+
+gemspec path: "../"

--- a/gemfiles/mongoid_9.gemfile
+++ b/gemfiles/mongoid_9.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 9.0"
+
+gemspec path: "../"

--- a/mongoid-autoinc.gemspec
+++ b/mongoid-autoinc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r(^(test|spec|features)/))
   s.require_path = 'lib'
 
-  s.add_dependency 'mongoid', ['>= 6.0', '< 9.0']
+  s.add_dependency 'mongoid', ['>= 6.0', '< 10.0']
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'foreman'


### PR DESCRIPTION
this is based on #43 

this is for easier testing against dependencies, adds github ci workflow, matrix maybe extensive, can be cut down, it totals in 100 jobs
<img width="1654" alt="image" src="https://github.com/user-attachments/assets/a33c85f7-5f41-438d-bf5a-b33f73bb4b3d">
- test against mongo 4 to 8
- mongoid from `~> 6.0` to `~> 9.0`
- ruby 2.7, 3.0, 3.1, 3.2 and 3.3

also updated readme badges and how to run specs instructions



